### PR TITLE
added options of inlining _List_fromArray calls with object literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9471,6 +9471,11 @@
         "yn": "3.1.1"
       }
     },
+    "ts-union": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ts-union/-/ts-union-2.2.1.tgz",
+      "integrity": "sha512-GLHuuu+N+n3mHY8/XzHUbuXf64Xy2nzYUa1/8rNCtkP6pD3mTiSM5OIyxV81ecT33S3i7lbVWdvCtyFmS8rplw=="
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "tree-sitter": "^0.16.1",
-    "tree-sitter-elm": "^2.7.9"
+    "tree-sitter-elm": "^2.7.9",
+    "ts-union": "^2.2.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,10 @@ import {
 } from './experiments/inlineWrappedFunctions';
 import { Mode } from './experiments/types';
 
-import { createInlineListFromArrayTransformer } from './experiments/inlineListFromArray';
+import {
+  createInlineListFromArrayTransformer,
+  InlineMode,
+} from './experiments/inlineListFromArray';
 
 const elmOutput = `
 var $elm$core$Maybe$Nothing = {$: 'Nothing'};
@@ -90,7 +93,10 @@ console.log(printer.printFile(sourceWithInlinedFuntioncs));
 console.log(
   '----------AFTER INLINE _List_fromArray TRANSFORM ----------------'
 );
-const inlineListFromArrayCalls = createInlineListFromArrayTransformer();
+const inlineListFromArrayCalls = createInlineListFromArrayTransformer(
+  InlineMode.UsingLiteralObjects(Mode.Prod)
+  // InlineMode.UsingConsFunc
+);
 const [sourceWithInlinedListFromArr] = ts.transform(
   sourceWithInlinedFuntioncs,
   [inlineListFromArrayCalls]


### PR DESCRIPTION
added different inline options 
```js
// initial 
_List_fromArray(["a", "b", "c"]);

// with InlineMode.UsingConsFunc
_List_cons("a", _List_cons("b", _List_cons("c", _List_Nil)))

// with InlineMode.UsingLiteralObjects(Mode.Prod)
({ $: 1, a: "a", b: { $: 1, a: "b", b: { $: 1, a: "c", b: _List_Nil } } });

// with InlineMode.UsingLiteralObjects(Mode.Dev) 
({ $: "::", a: "a", b: { $: "::", a: "b", b: { $: "::", a: "c", b: _List_Nil } } });
```

Note that inline options are more verbose but should be faster during runtime execution because there is nothing left to compute.

Also this PR fixes a bug with the order in the list