### PR TITLE
More flexible replacements

### DIFF
--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -1,6 +1,6 @@
 
 import ts, { isIdentifier } from 'typescript';
-import { ast } from './utils/create';
+import { ast, astNodes } from './utils/create';
 
 export const replace = (
   replacements: { [name: string]: string }
@@ -17,7 +17,7 @@ export const replace = (
               const name = node.name;
               if (isIdentifier(name) && name.text in replacements) {
                 const key = name.text as keyof typeof replacements;
-                return ast(replacements[key]);
+                return astNodes(replacements[key]);
               }
             }
             return ts.visitEachChild(node, visitor, context);

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -13,6 +13,12 @@ export const replace = (
                 const key = name.text as keyof typeof replacements;
                 return ast(replacements[key]);
               }
+            } else if (ts.isFunctionDeclaration(node)) {
+              const name = node.name;
+              if (isIdentifier(name) && name.text in replacements) {
+                const key = name.text as keyof typeof replacements;
+                return ast(replacements[key]);
+              }
             }
             return ts.visitEachChild(node, visitor, context);
         };

--- a/src/transforms/utils/create.ts
+++ b/src/transforms/utils/create.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 
 export const ast = (sourceText: string): ts.Node => {
     const source = ts.createSourceFile('bla', sourceText, ts.ScriptTarget.ES2018);
-    return source.statements[0];
+    return source.statements;
 };
 
 export function create(name: string, body: ts.Node): ts.Node {

--- a/src/transforms/utils/create.ts
+++ b/src/transforms/utils/create.ts
@@ -3,8 +3,13 @@ import ts from 'typescript';
 
 export const ast = (sourceText: string): ts.Node => {
     const source = ts.createSourceFile('bla', sourceText, ts.ScriptTarget.ES2018);
-    return source.statements;
+    return source.statements[0];
 };
+
+export const astNodes = (sourceText: string): [ts.Node] => {
+    const source = ts.createSourceFile('bla', sourceText, ts.ScriptTarget.ES2018);
+    return source.statements;
+}
 
 export function create(name: string, body: ts.Node): ts.Node {
     if (


### PR DESCRIPTION
This PR does two things:

1. replacements can now switch out a function declaration as opposed to just variables. (allows replacing kernel F2/A2 functions).
2. replacements can replace a variable/function with more than one statement. (allows to replace, say, the F function with a whole ton of stuff)