### PR TITLE
Fix typescript compile errors in replacement code

### DIFF
--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -15,7 +15,7 @@ export const replace = (
               }
             } else if (ts.isFunctionDeclaration(node)) {
               const name = node.name;
-              if (isIdentifier(name) && name.text in replacements) {
+              if (name && isIdentifier(name) && name.text in replacements) {
                 const key = name.text as keyof typeof replacements;
                 return astNodes(replacements[key]);
               }

--- a/src/transforms/utils/create.ts
+++ b/src/transforms/utils/create.ts
@@ -6,9 +6,9 @@ export const ast = (sourceText: string): ts.Node => {
     return source.statements[0];
 };
 
-export const astNodes = (sourceText: string): [ts.Node] => {
+export const astNodes = (sourceText: string): ts.Node[] => {
     const source = ts.createSourceFile('bla', sourceText, ts.ScriptTarget.ES2018);
-    return source.statements;
+    return Array.from(source.statements);
 }
 
 export function create(name: string, body: ts.Node): ts.Node {


### PR DESCRIPTION
In a previous PR I added a feature that let's your replace a JS definition with multiple statements. This code didn't actually type check.

This PR fixes the type errors introduced by my previous PR.