### PR TITLE
Add Node.js library API

### DIFF
--- a/bin/elm-optimize-level-2.js
+++ b/bin/elm-optimize-level-2.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-const index = require('../dist/index.js');
+const index = require('../dist/bin.js');

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,7 @@
+// tslint:disable-next-line no-require-imports no-var-requires
 import program from 'commander';
 import chalk from 'chalk';
-import { run } from './index';
+import { run } from './run';
 const { version } = require('../package.json');
 // import * as BenchInit from './benchmark/init'
 // import * as Benchmark from './benchmark/benchmark';
@@ -28,8 +29,11 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   .parse(process.argv);
 
 const { output, optimizeSpeed } = program.opts();
-run({
-  inputFilePath: program.args[0],
-  outputFilePath: output,
-  optimizeSpeed
-}).catch((e) => console.error(e));
+run(
+  {
+    inputFilePath: program.args[0],
+    outputFilePath: output,
+    optimizeSpeed
+  },
+  console.log.bind(console),
+).catch((e) => console.error(e));

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,4 +1,3 @@
-// tslint:disable-next-line no-require-imports no-var-requires
 import program from 'commander';
 import chalk from 'chalk';
 import { run } from './run';

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -36,4 +36,7 @@ run(
     optimizeSpeed
   },
   console.log.bind(console),
-).catch((e) => console.error(e));
+).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -36,6 +36,7 @@ run(
     outputFilePath: output,
     optimizeSpeed,
     verbose,
+    processOpts: { stdio: ['inherit', 'ignore', 'inherit'] },
   },
   console.log.bind(console),
 ).catch((e) => {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -37,6 +37,6 @@ run(
   },
   console.log.bind(console),
 ).catch((e) => {
-  console.error(e);
+  console.error(e.toString());
   process.exit(1);
 });

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,41 @@
+// tslint:disable-next-line no-require-imports no-var-requires
+import program from 'commander';
+import * as path from 'path';
+import * as Transform from './transform';
+import { toolDefaults } from './types';
+import { compileToStringSync } from 'node-elm-compiler';
+import * as fs from 'fs';
+import chalk from 'chalk';
+const { version } = require('../package.json');
+// import * as BenchInit from './benchmark/init'
+// import * as Benchmark from './benchmark/benchmark';
+// import * as Reporting from './benchmark/reporting';
+
+program
+  .version(version)
+  .description(
+    `${chalk.yellow('Elm Optimize Level 2!')}
+    
+This applies a second level of optimization to the javascript that Elm creates.
+
+Make sure you're familiar with Elm's built-in optimization first: ${chalk.cyan(
+      'https://guide.elm-lang.org/optimization/asset_size.html'
+    )}
+
+Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and then I'll make some more optimizations!`
+  )
+  .usage('[options] <src/Main.elm>')
+  .option('--output <output>', 'the javascript file to create.', 'elm.js')
+  .option('-O3, --optimize-speed', 'Enable optimizations that likely increases asset size', false)
+  // .option('--init-benchmark <dir>', 'Generate some files to help run benchmarks')
+  // .option('--benchmark <dir>', 'Run the benchmark in the given directory.')
+  // .option('--replacements <dir>', 'Replace stuff')
+  .parse(process.argv);
+
+const { output, optimizeSpeed } = program.opts();
+console.log(program.opts());
+// run({
+//   inputFilePath: program.args[0],
+//   outputFilePath: output,
+//   optimizeSpeed
+// }).catch((e) => console.error(e));

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -23,12 +23,13 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   .usage('[options] <src/Main.elm>')
   .option('--output <output>', 'the javascript file to create.', 'elm.js')
   .option('-O3, --optimize-speed', 'Enable optimizations that likely increases asset size', false)
+  .option('--verbose', 'Show more error details, useful to provide better bug reports', false)
   // .option('--init-benchmark <dir>', 'Generate some files to help run benchmarks')
   // .option('--benchmark <dir>', 'Run the benchmark in the given directory.')
   // .option('--replacements <dir>', 'Replace stuff')
   .parse(process.argv);
 
-const { output, optimizeSpeed } = program.opts();
+const { output, optimizeSpeed, verbose } = program.opts();
 run(
   {
     inputFilePath: program.args[0],
@@ -37,6 +38,10 @@ run(
   },
   console.log.bind(console),
 ).catch((e) => {
-  console.error(e.toString());
+  if (verbose) {
+    console.error(e);
+  } else {
+    console.error(e.toString());
+  }
   process.exit(1);
 });

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -34,7 +34,8 @@ run(
   {
     inputFilePath: program.args[0],
     outputFilePath: output,
-    optimizeSpeed
+    optimizeSpeed,
+    verbose,
   },
   console.log.bind(console),
 ).catch((e) => {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -38,6 +38,7 @@ run(
     verbose,
     processOpts: { stdio: ['inherit', 'ignore', 'inherit'] },
   },
+  program.helpInformation(),
   console.log.bind(console),
 ).catch((e) => {
   if (verbose) {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,11 +1,6 @@
-// tslint:disable-next-line no-require-imports no-var-requires
 import program from 'commander';
-import * as path from 'path';
-import * as Transform from './transform';
-import { toolDefaults } from './types';
-import { compileToStringSync } from 'node-elm-compiler';
-import * as fs from 'fs';
 import chalk from 'chalk';
+import { run } from './index';
 const { version } = require('../package.json');
 // import * as BenchInit from './benchmark/init'
 // import * as Benchmark from './benchmark/benchmark';
@@ -33,9 +28,8 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   .parse(process.argv);
 
 const { output, optimizeSpeed } = program.opts();
-console.log(program.opts());
-// run({
-//   inputFilePath: program.args[0],
-//   outputFilePath: output,
-//   optimizeSpeed
-// }).catch((e) => console.error(e));
+run({
+  inputFilePath: program.args[0],
+  outputFilePath: output,
+  optimizeSpeed
+}).catch((e) => console.error(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export async function run(options: {
       verbose: false,
       processOpts: options.processOpts || { stdio: ['inherit', 'ignore', 'inherit'] },
     },
+    '',
     () => { }
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,119 +1,12 @@
-// tslint:disable-next-line no-require-imports no-var-requires
-import program from 'commander';
-import * as path from 'path';
-import * as Transform from './transform';
-import { toolDefaults } from './types';
-import { compileToStringSync } from 'node-elm-compiler';
-import * as fs from 'fs';
-// import * as BenchInit from './benchmark/init'
-// import * as Benchmark from './benchmark/benchmark';
-// import * as Reporting from './benchmark/reporting';
+import * as Run from './run';
 
 export async function run(options: {
   inputFilePath: string | undefined,
   outputFilePath: string | null,
   optimizeSpeed: boolean
 }) {
-  return runWithLogger(
+  return Run.run(
     options,
-    console.log.bind(console)
+    () => { }
   );
-}
-
-async function runWithLogger(
-  options: {
-    inputFilePath: string | undefined,
-    outputFilePath: string | null,
-    optimizeSpeed: boolean
-  },
-  log: (message?: any, ...optionalParams: any[]) => void
-) {
-  const dirname = process.cwd();
-  let jsSource: string = '';
-  let elmFilePath = undefined;
-
-  const replacements = null;
-  const inputFilePath = options.inputFilePath;
-  const o3Enabled = options.optimizeSpeed;
-
-  // if (program.initBenchmark) {
-  //   console.log(`Initializing benchmark ${program.initBenchmark}`)
-  //   BenchInit.generate(program.initBenchmark)
-  //   process.exit(0)
-  // }
-
-  //   if (program.benchmark) {
-  //       const options = {
-  //           compile: true,
-  //           gzip: true,
-  //           minify: true,
-  //           verbose: true,
-  //           assetSizes: true,
-  //           runBenchmark: [
-  //               {
-  //                   browser: Browser.Chrome,
-  //                   headless: true,
-  //               }
-  //           ],
-  //           transforms: benchmarkDefaults(o3Enabled, replacements),
-  //       };
-  //       const report = await Benchmark.run(options, [
-  //         {
-  //           name: 'Benchmark',
-  //           dir: program.benchmark,
-  //           elmFile: 'V8/Benchmark.elm',
-  //         }
-  //       ]);
-  //       console.log(Reporting.terminal(report));
-  // //       fs.writeFileSync('./results.markdown', Reporting.markdownTable(result));
-  //       process.exit(0)
-  //   }
-
-  if (inputFilePath && inputFilePath.endsWith('.js')) {
-    jsSource = fs.readFileSync(inputFilePath, 'utf8');
-    log('Optimizing existing JS...');
-  } else if (inputFilePath && inputFilePath.endsWith('.elm')) {
-    elmFilePath = inputFilePath;
-    jsSource = compileToStringSync([inputFilePath], {
-      output: 'output/elm.opt.js',
-      cwd: dirname,
-      optimize: true,
-      processOpts:
-      // ignore stdout
-      {
-        stdio: ['inherit', 'ignore', 'inherit'],
-      },
-    });
-    if (jsSource != '') {
-      log('Compiled, optimizing JS...');
-    } else {
-      process.exit(1)
-    }
-  } else {
-    console.error('Please provide a path to an Elm file.');
-    program.outputHelp();
-    return;
-  }
-  if (jsSource != '') {
-    const transformed = await Transform.transform(
-      dirname,
-      jsSource,
-      elmFilePath,
-      false,
-      toolDefaults(o3Enabled, replacements),
-    );
-
-    // Make sure all the folders up to the output file exist, if not create them.
-    // This mirrors elm make behavior.
-    const outputDirectory = path.dirname(program.output);
-    if (!fs.existsSync(outputDirectory)) {
-      fs.mkdirSync(outputDirectory, { recursive: true });
-    }
-    fs.writeFileSync(program.output, transformed);
-    const fileName = path.basename(inputFilePath);
-    log('Success!');
-    log('');
-    log(`   ${fileName} ───> ${program.output}`);
-    log('');
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as Run from './run';
 
 export async function run(options: {
   inputFilePath: string | undefined,
-  outputFilePath: string | null,
+  outputFilePath: string,
   optimizeSpeed: boolean,
   processOpts: {
     stdio: [string, string, string],

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,32 +5,9 @@ import * as Transform from './transform';
 import { toolDefaults } from './types';
 import { compileToStringSync } from 'node-elm-compiler';
 import * as fs from 'fs';
-import chalk from 'chalk';
-const { version } = require('../package.json');
 // import * as BenchInit from './benchmark/init'
 // import * as Benchmark from './benchmark/benchmark';
 // import * as Reporting from './benchmark/reporting';
-
-program
-  .version(version)
-  .description(
-    `${chalk.yellow('Elm Optimize Level 2!')}
-    
-This applies a second level of optimization to the javascript that Elm creates.
-
-Make sure you're familiar with Elm's built-in optimization first: ${chalk.cyan(
-      'https://guide.elm-lang.org/optimization/asset_size.html'
-    )}
-
-Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and then I'll make some more optimizations!`
-  )
-  .usage('[options] <src/Main.elm>')
-  .option('--output <output>', 'the javascript file to create.', 'elm.js')
-  .option('-O3, --optimize-speed', 'Enable optimizations that likely increases asset size', false)
-  // .option('--init-benchmark <dir>', 'Generate some files to help run benchmarks')
-  // .option('--benchmark <dir>', 'Run the benchmark in the given directory.')
-  // .option('--replacements <dir>', 'Replace stuff')
-  .parse(process.argv);
 
 export async function run(options: {
   inputFilePath: string | undefined,
@@ -65,32 +42,32 @@ async function runWithLogger(
   //   process.exit(0)
   // }
 
-//   if (program.benchmark) {
-//       const options = {
-//           compile: true,
-//           gzip: true,
-//           minify: true,
-//           verbose: true,
-//           assetSizes: true,
-//           runBenchmark: [
-//               {
-//                   browser: Browser.Chrome,
-//                   headless: true,
-//               }
-//           ],
-//           transforms: benchmarkDefaults(o3Enabled, replacements),
-//       };
-//       const report = await Benchmark.run(options, [
-//         {
-//           name: 'Benchmark',
-//           dir: program.benchmark,
-//           elmFile: 'V8/Benchmark.elm',
-//         }
-//       ]);
-//       console.log(Reporting.terminal(report));
-// //       fs.writeFileSync('./results.markdown', Reporting.markdownTable(result));
-//       process.exit(0)
-//   }
+  //   if (program.benchmark) {
+  //       const options = {
+  //           compile: true,
+  //           gzip: true,
+  //           minify: true,
+  //           verbose: true,
+  //           assetSizes: true,
+  //           runBenchmark: [
+  //               {
+  //                   browser: Browser.Chrome,
+  //                   headless: true,
+  //               }
+  //           ],
+  //           transforms: benchmarkDefaults(o3Enabled, replacements),
+  //       };
+  //       const report = await Benchmark.run(options, [
+  //         {
+  //           name: 'Benchmark',
+  //           dir: program.benchmark,
+  //           elmFile: 'V8/Benchmark.elm',
+  //         }
+  //       ]);
+  //       console.log(Reporting.terminal(report));
+  // //       fs.writeFileSync('./results.markdown', Reporting.markdownTable(result));
+  //       process.exit(0)
+  //   }
 
   if (inputFilePath && inputFilePath.endsWith('.js')) {
     jsSource = fs.readFileSync(inputFilePath, 'utf8');
@@ -102,10 +79,10 @@ async function runWithLogger(
       cwd: dirname,
       optimize: true,
       processOpts:
-        // ignore stdout
-        {
-          stdio: ['inherit', 'ignore', 'inherit'],
-        },
+      // ignore stdout
+      {
+        stdio: ['inherit', 'ignore', 'inherit'],
+      },
     });
     if (jsSource != '') {
       log('Compiled, optimizing JS...');
@@ -140,10 +117,3 @@ async function runWithLogger(
     log('');
   }
 }
-
-const { output, optimizeSpeed } = program.opts();
-run({
-  inputFilePath: program.args[0],
-  outputFilePath: output,
-  optimizeSpeed
-}).catch((e) => console.error(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   // .option('--replacements <dir>', 'Replace stuff')
   .parse(process.argv);
 
-async function run(inputFilePath: string | undefined, options: { output: string | null, optimizeSpeed: boolean }) {
+async function run(inputFilePath: string | undefined, options: { outputFilePath: string | null, optimizeSpeed: boolean }) {
   const dirname = process.cwd();
   let jsSource: string = '';
   let elmFilePath = undefined;
@@ -123,4 +123,4 @@ async function run(inputFilePath: string | undefined, options: { output: string 
 }
 
 const { output, optimizeSpeed } = program.opts();
-run(program.args[0], { output, optimizeSpeed }).catch((e) => console.error(e));
+run(program.args[0], { outputFilePath: output, optimizeSpeed }).catch((e) => console.error(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export async function run(options: {
   optimizeSpeed: boolean
 }) {
   return Run.run(
-    options,
+    { ...options, verbose: false },
     () => { }
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,17 @@ import * as Run from './run';
 export async function run(options: {
   inputFilePath: string | undefined,
   outputFilePath: string | null,
-  optimizeSpeed: boolean
+  optimizeSpeed: boolean,
+  processOpts: {
+    stdio: [string, string, string],
+  } | null,
 }) {
   return Run.run(
-    { ...options, verbose: false },
+    {
+      ...options,
+      verbose: false,
+      processOpts: options.processOpts || { stdio: ['inherit', 'ignore', 'inherit'] },
+    },
     () => { }
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,14 @@ async function run(options: {
   outputFilePath: string | null,
   optimizeSpeed: boolean
 }) {
+  return runWithLogger(options, console.log.bind(console));
+}
+
+async function runWithLogger(options: {
+  inputFilePath: string | undefined,
+  outputFilePath: string | null,
+  optimizeSpeed: boolean
+}, log: (message?: any, ...optionalParams: any[]) => void) {
   const dirname = process.cwd();
   let jsSource: string = '';
   let elmFilePath = undefined;
@@ -80,7 +88,7 @@ async function run(options: {
 
   if (inputFilePath && inputFilePath.endsWith('.js')) {
     jsSource = fs.readFileSync(inputFilePath, 'utf8');
-    console.log('Optimizing existing JS...');
+    log('Optimizing existing JS...');
   } else if (inputFilePath && inputFilePath.endsWith('.elm')) {
     elmFilePath = inputFilePath;
     jsSource = compileToStringSync([inputFilePath], {
@@ -94,7 +102,7 @@ async function run(options: {
         },
     });
     if (jsSource != '') {
-      console.log('Compiled, optimizing JS...');
+      log('Compiled, optimizing JS...');
     } else {
       process.exit(1)
     }
@@ -120,10 +128,10 @@ async function run(options: {
     }
     fs.writeFileSync(program.output, transformed);
     const fileName = path.basename(inputFilePath);
-    console.log('Success!');
-    console.log('');
-    console.log(`   ${fileName} ───> ${program.output}`);
-    console.log('');
+    log('Success!');
+    log('');
+    log(`   ${fileName} ───> ${program.output}`);
+    log('');
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   // .option('--replacements <dir>', 'Replace stuff')
   .parse(process.argv);
 
-async function run(options: {
+export async function run(options: {
   inputFilePath: string | undefined,
   outputFilePath: string | null,
   optimizeSpeed: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,11 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   // .option('--replacements <dir>', 'Replace stuff')
   .parse(process.argv);
 
-async function run(inputFilePath: string | undefined) {
+async function run(inputFilePath: string | undefined, options: { output: string | null, optimizeSpeed: boolean }) {
   const dirname = process.cwd();
   let jsSource: string = '';
   let elmFilePath = undefined;
 
-  const options = program.opts();
   const replacements = null;
   const o3Enabled = options.optimizeSpeed;
 
@@ -123,5 +122,5 @@ async function run(inputFilePath: string | undefined) {
   }
 }
 
-
-run(program.args[0]).catch((e) => console.error(e));
+const { output, optimizeSpeed } = program.opts();
+run(program.args[0], { output, optimizeSpeed }).catch((e) => console.error(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,17 @@ Give me an Elm file, I'll compile it behind the scenes using Elm 0.19.1, and the
   // .option('--replacements <dir>', 'Replace stuff')
   .parse(process.argv);
 
-async function run(inputFilePath: string | undefined, options: { outputFilePath: string | null, optimizeSpeed: boolean }) {
+async function run(options: {
+  inputFilePath: string | undefined,
+  outputFilePath: string | null,
+  optimizeSpeed: boolean
+}) {
   const dirname = process.cwd();
   let jsSource: string = '';
   let elmFilePath = undefined;
 
   const replacements = null;
+  const inputFilePath = options.inputFilePath;
   const o3Enabled = options.optimizeSpeed;
 
   // if (program.initBenchmark) {
@@ -123,4 +128,8 @@ async function run(inputFilePath: string | undefined, options: { outputFilePath:
 }
 
 const { output, optimizeSpeed } = program.opts();
-run(program.args[0], { outputFilePath: output, optimizeSpeed }).catch((e) => console.error(e));
+run({
+  inputFilePath: program.args[0],
+  outputFilePath: output,
+  optimizeSpeed
+}).catch((e) => console.error(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,14 +37,20 @@ async function run(options: {
   outputFilePath: string | null,
   optimizeSpeed: boolean
 }) {
-  return runWithLogger(options, console.log.bind(console));
+  return runWithLogger(
+    options,
+    console.log.bind(console)
+  );
 }
 
-async function runWithLogger(options: {
-  inputFilePath: string | undefined,
-  outputFilePath: string | null,
-  optimizeSpeed: boolean
-}, log: (message?: any, ...optionalParams: any[]) => void) {
+async function runWithLogger(
+  options: {
+    inputFilePath: string | undefined,
+    outputFilePath: string | null,
+    optimizeSpeed: boolean
+  },
+  log: (message?: any, ...optionalParams: any[]) => void
+) {
   const dirname = process.cwd();
   let jsSource: string = '';
   let elmFilePath = undefined;

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,6 +19,10 @@ export async function run(
   },
   log: (message?: any, ...optionalParams: any[]) => void
 ) {
+  if (!options.outputFilePath) {
+    throw new Error('Missing an output file path');
+  }
+
   const dirname = process.cwd();
   let jsSource: string = '';
   let elmFilePath = undefined;

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,3 @@
-// tslint:disable-next-line no-require-imports no-var-requires
 import * as path from 'path';
 import * as Transform from './transform';
 import { toolDefaults } from './types';

--- a/src/run.ts
+++ b/src/run.ts
@@ -87,27 +87,30 @@ export async function run(
   } else {
     throw new Error(`Please provide a path to an Elm file.\n${helpInformation}`.trim());
   }
-  if (jsSource != '') {
-    const transformed = await Transform.transform(
-      dirname,
-      jsSource,
-      elmFilePath,
-      options.verbose,
-      toolDefaults(o3Enabled, replacements),
-    );
 
-    // Make sure all the folders up to the output file exist, if not create them.
-    // This mirrors elm make behavior.
-    const outputDirectory = path.dirname(options.outputFilePath);
-    if (!fs.existsSync(outputDirectory)) {
-      fs.mkdirSync(outputDirectory, { recursive: true });
-    }
-    fs.writeFileSync(options.outputFilePath, transformed);
-    const fileName = path.basename(inputFilePath);
-    log('Success!');
-    log('');
-    log(`   ${fileName} ───> ${options.outputFilePath}`);
-    log('');
-    return options.outputFilePath;
+  if (jsSource == '') {
+    throw new Error('Target JS file is empty.');
   }
+
+  const transformed = await Transform.transform(
+    dirname,
+    jsSource,
+    elmFilePath,
+    options.verbose,
+    toolDefaults(o3Enabled, replacements),
+  );
+
+  // Make sure all the folders up to the output file exist, if not create them.
+  // This mirrors elm make behavior.
+  const outputDirectory = path.dirname(options.outputFilePath);
+  if (!fs.existsSync(outputDirectory)) {
+    fs.mkdirSync(outputDirectory, { recursive: true });
+  }
+  fs.writeFileSync(options.outputFilePath, transformed);
+  const fileName = path.basename(inputFilePath);
+  log('Success!');
+  log('');
+  log(`   ${fileName} ───> ${options.outputFilePath}`);
+  log('');
+  return options.outputFilePath;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,4 @@
 // tslint:disable-next-line no-require-imports no-var-requires
-import program from 'commander';
 import * as path from 'path';
 import * as Transform from './transform';
 import { toolDefaults } from './types';
@@ -17,6 +16,7 @@ export async function run(
     verbose: boolean,
     processOpts: { stdio: [string, string, string] },
   },
+  helpInformation: string,
   log: (message?: any, ...optionalParams: any[]) => void
 ) {
   if (!options.outputFilePath) {
@@ -85,7 +85,7 @@ export async function run(
       throw new Error('An error occurred when compiling your application with Elm 0.19.1.');
     }
   } else {
-    throw new Error('Please provide a path to an Elm file.\n' + program.helpInformation());
+    throw new Error(`Please provide a path to an Elm file.\n${helpInformation}`.trim());
   }
   if (jsSource != '') {
     const transformed = await Transform.transform(

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,7 +13,8 @@ export async function run(
   options: {
     inputFilePath: string | undefined,
     outputFilePath: string | null,
-    optimizeSpeed: boolean
+    optimizeSpeed: boolean,
+    verbose: boolean,
   },
   log: (message?: any, ...optionalParams: any[]) => void
 ) {
@@ -86,7 +87,7 @@ export async function run(
       dirname,
       jsSource,
       elmFilePath,
-      false,
+      options.verbose,
       toolDefaults(o3Enabled, replacements),
     );
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -15,6 +15,7 @@ export async function run(
     outputFilePath: string | null,
     optimizeSpeed: boolean,
     verbose: boolean,
+    processOpts: { stdio: [string, string, string] },
   },
   log: (message?: any, ...optionalParams: any[]) => void
 ) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -76,7 +76,7 @@ export async function run(
     if (jsSource != '') {
       log('Compiled, optimizing JS...');
     } else {
-      process.exit(1)
+      throw new Error('An error occurred when compiling your application with Elm 0.19.1.');
     }
   } else {
     throw new Error('Please provide a path to an Elm file.\n' + program.helpInformation());

--- a/src/run.ts
+++ b/src/run.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 export async function run(
   options: {
     inputFilePath: string | undefined,
-    outputFilePath: string | null,
+    outputFilePath: string,
     optimizeSpeed: boolean,
     verbose: boolean,
     processOpts: { stdio: [string, string, string] },
@@ -94,15 +94,16 @@ export async function run(
 
     // Make sure all the folders up to the output file exist, if not create them.
     // This mirrors elm make behavior.
-    const outputDirectory = path.dirname(program.output);
+    const outputDirectory = path.dirname(options.outputFilePath);
     if (!fs.existsSync(outputDirectory)) {
       fs.mkdirSync(outputDirectory, { recursive: true });
     }
-    fs.writeFileSync(program.output, transformed);
+    fs.writeFileSync(options.outputFilePath, transformed);
     const fileName = path.basename(inputFilePath);
     log('Success!');
     log('');
-    log(`   ${fileName} ───> ${program.output}`);
+    log(`   ${fileName} ───> ${options.outputFilePath}`);
     log('');
+    return options.outputFilePath;
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -79,9 +79,7 @@ export async function run(
       process.exit(1)
     }
   } else {
-    console.error('Please provide a path to an Elm file.');
-    program.outputHelp();
-    return;
+    throw new Error('Please provide a path to an Elm file.\n' + program.helpInformation());
   }
   if (jsSource != '') {
     const transformed = await Transform.transform(

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,108 @@
+// tslint:disable-next-line no-require-imports no-var-requires
+import program from 'commander';
+import * as path from 'path';
+import * as Transform from './transform';
+import { toolDefaults } from './types';
+import { compileToStringSync } from 'node-elm-compiler';
+import * as fs from 'fs';
+// import * as BenchInit from './benchmark/init'
+// import * as Benchmark from './benchmark/benchmark';
+// import * as Reporting from './benchmark/reporting';
+
+export async function run(
+  options: {
+    inputFilePath: string | undefined,
+    outputFilePath: string | null,
+    optimizeSpeed: boolean
+  },
+  log: (message?: any, ...optionalParams: any[]) => void
+) {
+  const dirname = process.cwd();
+  let jsSource: string = '';
+  let elmFilePath = undefined;
+
+  const replacements = null;
+  const inputFilePath = options.inputFilePath;
+  const o3Enabled = options.optimizeSpeed;
+
+  // if (program.initBenchmark) {
+  //   console.log(`Initializing benchmark ${program.initBenchmark}`)
+  //   BenchInit.generate(program.initBenchmark)
+  //   process.exit(0)
+  // }
+
+  //   if (program.benchmark) {
+  //       const options = {
+  //           compile: true,
+  //           gzip: true,
+  //           minify: true,
+  //           verbose: true,
+  //           assetSizes: true,
+  //           runBenchmark: [
+  //               {
+  //                   browser: Browser.Chrome,
+  //                   headless: true,
+  //               }
+  //           ],
+  //           transforms: benchmarkDefaults(o3Enabled, replacements),
+  //       };
+  //       const report = await Benchmark.run(options, [
+  //         {
+  //           name: 'Benchmark',
+  //           dir: program.benchmark,
+  //           elmFile: 'V8/Benchmark.elm',
+  //         }
+  //       ]);
+  //       console.log(Reporting.terminal(report));
+  // //       fs.writeFileSync('./results.markdown', Reporting.markdownTable(result));
+  //       process.exit(0)
+  //   }
+
+  if (inputFilePath && inputFilePath.endsWith('.js')) {
+    jsSource = fs.readFileSync(inputFilePath, 'utf8');
+    log('Optimizing existing JS...');
+  } else if (inputFilePath && inputFilePath.endsWith('.elm')) {
+    elmFilePath = inputFilePath;
+    jsSource = compileToStringSync([inputFilePath], {
+      output: 'output/elm.opt.js',
+      cwd: dirname,
+      optimize: true,
+      processOpts:
+      // ignore stdout
+      {
+        stdio: ['inherit', 'ignore', 'inherit'],
+      },
+    });
+    if (jsSource != '') {
+      log('Compiled, optimizing JS...');
+    } else {
+      process.exit(1)
+    }
+  } else {
+    console.error('Please provide a path to an Elm file.');
+    program.outputHelp();
+    return;
+  }
+  if (jsSource != '') {
+    const transformed = await Transform.transform(
+      dirname,
+      jsSource,
+      elmFilePath,
+      false,
+      toolDefaults(o3Enabled, replacements),
+    );
+
+    // Make sure all the folders up to the output file exist, if not create them.
+    // This mirrors elm make behavior.
+    const outputDirectory = path.dirname(program.output);
+    if (!fs.existsSync(outputDirectory)) {
+      fs.mkdirSync(outputDirectory, { recursive: true });
+    }
+    fs.writeFileSync(program.output, transformed);
+    const fileName = path.basename(inputFilePath);
+    log('Success!');
+    log('');
+    log(`   ${fileName} ───> ${program.output}`);
+    log('');
+  }
+}


### PR DESCRIPTION
I added a way for Node.js project to import the project as a library and apply the optimizations, this will be useful for running these optimizations in `elm-review`.

You can review the changes commit by commit, but here are the highlights (not in the order of commits):
- Split `index.js` into
  - `bin.js` which defines the `program` and handles the CLI part (and changed `bin/elm-optimize-level-2.js` to import this file).
  - `index.js` which is the `main` file for the library part
  - `run.js` which has the optimization-applyinh logic, and which is called from the previous 2 files.
- Added a lot more arguments to `run`, so that we can inject CLI or library-dependent behavior, and the wanted options from the CLI user or library user.
- Made `run` return the path to the output file
- Replaced process.exits and console.error by JS exceptions
- Replaced console.log calls by calls of an injectable function, in order for them not to appear in the library use
- Made program exit with an error for a lot of the already existing error cases
- Made it so that by default only the exception's error message is displayed, but added a verbose flag to show stack traces and enable verbose mode of the compiler (maybe this wasn't needed in retrospect).

Notes:
- I added some of the same options as for `node-elm-compiler`. There are more to add, and from my testing, I don't even need some of these for `elm-review`, since I went for the "use `elm-optimize-level-2` on a JS file, not an Elm file" for now.
- I haven't worked on making the commented benchmark work again. They probably need a bit of updating.


Let me know what you think. I hope I didn't break anything, tests are already broken in `master`.