### PR TITLE
Prevent creating folder if input and output file paths are the same

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -99,13 +99,11 @@ export async function run(
     toolDefaults(o3Enabled, replacements),
   );
 
-  if (inputFilePath !== options.outputFilePath) {
-    // Make sure all the folders up to the output file exist, if not create them.
-    // This mirrors elm make behavior.
-    const outputDirectory = path.dirname(options.outputFilePath);
-    if (!fs.existsSync(outputDirectory)) {
-      fs.mkdirSync(outputDirectory, { recursive: true });
-    }
+  // Make sure all the folders up to the output file exist, if not create them.
+  // This mirrors elm make behavior.
+  const outputDirectory = path.dirname(options.outputFilePath);
+  if (path.dirname(inputFilePath) !== outputDirectory && !fs.existsSync(outputDirectory)) {
+    fs.mkdirSync(outputDirectory, { recursive: true });
   }
 
   fs.writeFileSync(options.outputFilePath, transformed);

--- a/src/run.ts
+++ b/src/run.ts
@@ -99,12 +99,15 @@ export async function run(
     toolDefaults(o3Enabled, replacements),
   );
 
-  // Make sure all the folders up to the output file exist, if not create them.
-  // This mirrors elm make behavior.
-  const outputDirectory = path.dirname(options.outputFilePath);
-  if (!fs.existsSync(outputDirectory)) {
-    fs.mkdirSync(outputDirectory, { recursive: true });
+  if (inputFilePath !== options.outputFilePath) {
+    // Make sure all the folders up to the output file exist, if not create them.
+    // This mirrors elm make behavior.
+    const outputDirectory = path.dirname(options.outputFilePath);
+    if (!fs.existsSync(outputDirectory)) {
+      fs.mkdirSync(outputDirectory, { recursive: true });
+    }
   }
+
   fs.writeFileSync(options.outputFilePath, transformed);
   const fileName = path.basename(inputFilePath);
   log('Success!');


### PR DESCRIPTION
I'm looking into ways to make `elm-optimize-level-2` faster and this looked like an easy win, though it will likely not change a lot. This will likely be how I run `elm-optimize-level-2` in `elm-review` (it is in a branch), and I imagine others will as well.