### PR TITLE
Use processOpts from options

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -72,11 +72,7 @@ export async function run(
       output: 'output/elm.opt.js',
       cwd: dirname,
       optimize: true,
-      processOpts:
-      // ignore stdout
-      {
-        stdio: ['inherit', 'ignore', 'inherit'],
-      },
+      processOpts: options.processOpts,
     });
     if (jsSource != '') {
       log('Compiled, optimizing JS...');


### PR DESCRIPTION
I previously added processOpts as an argument, but forgot to use. The value used in the CLI and the default value for the Node.js lib are the same as the one removed here. 