### PR TITLE
Remove unnecessary work from $elm$core$List$concat replacement

### DIFF
--- a/src/replacements/list/$elm$core$List$concat.js
+++ b/src/replacements/list/$elm$core$List$concat.js
@@ -1,9 +1,9 @@
 var $elm$core$List$concat = function (lists) {
-  var tmp = _List_Cons(undefined, _List_Nil);
-  var end = tmp;
   if (!lists.b) {
     return _List_Nil;
   }
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
   for (; lists.b.b; lists = lists.b) {
     var xs = lists.a;
     for (; xs.b; xs = xs.b) {


### PR DESCRIPTION
I stumbled upon this replacement file, and noticed some variables where always defined but only used in one of the branches.

Here is a benchmark comparing the 2: https://jsbench.me/fpkuwkrzz9/1

The result is that for empty lists the newer version is faster.
![Screenshot from 2021-10-18 13-30-18](https://user-images.githubusercontent.com/3869412/137722391-198f9d87-250f-422e-9c2c-fa39863b451b.png)


I also tried it for non-empty list, and benchmarks seems to indicate one is faster than the other about half of the time, which I imagine means they're roughly equivalent. https://jsbench.me/jwkuwl92mi/1

![Screenshot from 2021-10-18 13-39-39](https://user-images.githubusercontent.com/3869412/137724004-4eae0a6f-6786-4756-8285-2b9d0f1f6859.png)
![Screenshot from 2021-10-18 13-40-06](https://user-images.githubusercontent.com/3869412/137724007-a770d294-3b18-428f-adcd-d110dec111e7.png)
![Screenshot from 2021-10-18 13-40-31](https://user-images.githubusercontent.com/3869412/137724009-9f984c14-a6e9-4cd7-83a1-d1a74cc98cf5.png)
![Screenshot from 2021-10-18 13-41-11](https://user-images.githubusercontent.com/3869412/137724010-54e55abe-b8f6-4537-a0ab-020a5371c14f.png)


