### PR TITLE
replace transforms: Don't go through all nodes

### DIFF
--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -14,12 +14,14 @@ export const replace = (
                 const key = name.text as keyof typeof replacements;
                 return ast(replacements[key]);
               }
+              return node;
             } else if (ts.isFunctionDeclaration(node)) {
               const name = node.name;
               if (name && isIdentifier(name) && replacements.hasOwnProperty(name.text)) {
                 const key = name.text as keyof typeof replacements;
                 return astNodes(replacements[key]);
               }
+              return node;
             }
             return ts.visitEachChild(node, visitor, context);
         };


### PR DESCRIPTION
This makes it so that the `replace` transformer stops recursing through the AST as soon as it finds the level where it finds some statements.

I ran level-2 5 times on each version. Times are in milliseconds (and ordered from lower to higher)

| Version | Attempt 1 | 2 | 3 | 4 | 5 |
|--|--|--|--|--|--|
| Before | 1595 | 1658 | 1691 | 1709 | 1769 | 1684 |
| After | 1534 | 1541 | 1546 | 1566 | 1580 | 1553 |

This averages on a ~8% speedup on the entire run of the program.


I compared the output of level-2 before and after this change and they are identical.


I haven't looked at other transformations, but maybe the same optimization can be applied in other places as well.