### PR TITLE
Single replace pass

### DIFF
--- a/src/fs_util.ts
+++ b/src/fs_util.ts
@@ -1,8 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-export function readFilesSync(dir: string): {[key: string]: string} | null {
-  let foundAnything = false
+export function readFilesSync(dir: string): {[key: string]: string} {
   const files: {[key: string]: string} = {};
 
   fs.readdirSync(dir).forEach(filename => {
@@ -14,14 +13,8 @@ export function readFilesSync(dir: string): {[key: string]: string} | null {
     if (isFile) {
          const content = fs.readFileSync(path.join(dir, filename))
          files[name] = content.toString()
-         foundAnything = true
     }
   });
 
-  if (foundAnything) {
-    return files;
-  } else {
-    return null
-  }
-
+  return files;
 }

--- a/src/fs_util.ts
+++ b/src/fs_util.ts
@@ -1,20 +1,22 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as util from 'util';
 
-export function readFilesSync(dir: string): {[key: string]: string} {
+const readdir = util.promisify(fs.readdir);
+const readFile = util.promisify(fs.readFile);
+
+export async function readFiles(dir: string): Promise<{[key: string]: string}> {
   const files: {[key: string]: string} = {};
 
-  fs.readdirSync(dir).forEach(filename => {
-    const name = path.parse(filename).name;
-    const filepath = path.resolve(dir, filename);
-    const stat = fs.statSync(filepath);
-    const isFile = stat.isFile();
+  const foos = await readdir(dir, {withFileTypes: true});
 
-    if (isFile) {
-         const content = fs.readFileSync(path.join(dir, filename))
-         files[name] = content.toString()
+  await Promise.all(foos.map(async file => {
+    if (file.isFile()) {
+      const content = await readFile(path.join(dir, file.name))
+      const name = path.parse(file.name).name;
+      files[name] = content.toString()
     }
-  });
+  }));
 
   return files;
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -78,11 +78,6 @@ export const transform = async (
     source = results.transformed[0];
   }
 
-  let replacementTransformer = inlineEquality()
-  if (transforms.replacements != null){
-    replacementTransformer = Replace.replace(transforms.replacements)
-  }
-
   const replacements = removeDisabled([
     [transforms.fastCurriedFns, '/../replacements/faster-function-wrappers'],
     [transforms.replaceListFunctions, '/../replacements/list'],
@@ -91,8 +86,7 @@ export const transform = async (
 
   let inlineCtx: InlineContext | undefined;
   const transformations: any[] = removeDisabled([
-    [transforms.replacements != null, replacementTransformer ],
-    [true, Replace.fromFiles(replacements)],
+    [transforms.replacements != null || replacements.length > 0, Replace.fromFiles(transforms.replacements || {}, replacements)],
     [transforms.v8Analysis, v8Debug],
     [transforms.variantShapes, normalizeVariantShapes],
     [transforms.inlineFunctions, createFunctionInlineTransformer(verbose, transforms.fastCurriedFns)],

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -83,13 +83,16 @@ export const transform = async (
     replacementTransformer = Replace.replace(transforms.replacements)
   }
 
+  const replacements = removeDisabled([
+    [transforms.fastCurriedFns, '/../replacements/faster-function-wrappers'],
+    [transforms.replaceListFunctions, '/../replacements/list'],
+    [transforms.replaceStringFunctions, '/../replacements/string'],
+  ]);
 
   let inlineCtx: InlineContext | undefined;
   const transformations: any[] = removeDisabled([
     [transforms.replacements != null, replacementTransformer ],
-    [transforms.fastCurriedFns, Replace.from_file('/../replacements/faster-function-wrappers') ],
-    [transforms.replaceListFunctions,  Replace.from_file('/../replacements/list') ],
-    [transforms.replaceStringFunctions, Replace.from_file('/../replacements/string') ],
+    [true, Replace.fromFiles(replacements)],
     [transforms.v8Analysis, v8Debug],
     [transforms.variantShapes, normalizeVariantShapes],
     [transforms.inlineFunctions, createFunctionInlineTransformer(verbose, transforms.fastCurriedFns)],

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -86,7 +86,7 @@ export const transform = async (
 
   let inlineCtx: InlineContext | undefined;
   const transformations: any[] = removeDisabled([
-    [transforms.replacements != null || replacements.length > 0, Replace.fromFiles(transforms.replacements || {}, replacements)],
+    [transforms.replacements != null || replacements.length > 0, await Replace.fromFiles(transforms.replacements || {}, replacements)],
     [transforms.v8Analysis, v8Debug],
     [transforms.variantShapes, normalizeVariantShapes],
     [transforms.inlineFunctions, createFunctionInlineTransformer(verbose, transforms.fastCurriedFns)],

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -37,3 +37,15 @@ export const from_file = (path: string) => {
   }
   return replace(replacements)
 }
+
+export const fromFiles = (paths: string[]) => {
+  const foundReplacements = paths.reduce((res, path) => {
+    const read = readFilesSync(__dirname + path);
+    if (read) {
+      return Object.assign(res, read);
+    }
+    return res;
+  }, Object.create(null));
+
+  return replace(foundReplacements);
+}

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -28,16 +28,6 @@ export const replace = (
     };
 };
 
-
-export const from_file = (path: string) => {
-  const read = readFilesSync(__dirname + path)
-  let replacements = {}
-  if (read) {
-    replacements = read
-  }
-  return replace(replacements)
-}
-
 export const fromFiles = (paths: string[]) => {
   const foundReplacements = paths.reduce((res, path) => {
     const read = readFilesSync(__dirname + path);

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -30,11 +30,7 @@ export const replace = (
 
 export const fromFiles = (paths: string[]) => {
   const foundReplacements = paths.reduce((res, path) => {
-    const read = readFilesSync(__dirname + path);
-    if (read) {
-      return Object.assign(res, read);
-    }
-    return res;
+    return Object.assign(res, readFilesSync(__dirname + path));
   }, {});
 
   return replace(foundReplacements);

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -1,7 +1,7 @@
 
 import ts, { isIdentifier } from 'typescript';
 import { ast, astNodes } from './utils/create';
-import { readFilesSync } from '../fs_util';
+import { readFiles } from '../fs_util';
 
 export const replace = (
   replacements: { [name: string]: string }
@@ -28,10 +28,14 @@ export const replace = (
     };
 };
 
-export const fromFiles = (existingReplacements: {[key: string]: string}, paths: string[]) : ts.TransformerFactory<ts.SourceFile> => {
-  const foundReplacements = paths.reduce((res, path) => {
-    return Object.assign(res, readFilesSync(__dirname + path));
-  }, existingReplacements);
+export const fromFiles = async (existingReplacements: {[key: string]: string}, paths: string[]) : Promise<ts.TransformerFactory<ts.SourceFile>> => {
+  const fileObjects = await Promise.all(paths.map(path => readFiles(__dirname + path)));
+
+  const foundReplacements = fileObjects
+      .reduce(
+        (a, b) => Object.assign(a, b),
+        Object.assign({}, existingReplacements)
+      );
 
   return replace(foundReplacements);
 }

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -28,10 +28,10 @@ export const replace = (
     };
 };
 
-export const fromFiles = (paths: string[]) : ts.TransformerFactory<ts.SourceFile> => {
+export const fromFiles = (existingReplacements: {[key: string]: string}, paths: string[]) : ts.TransformerFactory<ts.SourceFile> => {
   const foundReplacements = paths.reduce((res, path) => {
     return Object.assign(res, readFilesSync(__dirname + path));
-  }, {});
+  }, existingReplacements);
 
   return replace(foundReplacements);
 }

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -28,7 +28,7 @@ export const replace = (
     };
 };
 
-export const fromFiles = (paths: string[]) => {
+export const fromFiles = (paths: string[]) : ts.TransformerFactory<ts.SourceFile> => {
   const foundReplacements = paths.reduce((res, path) => {
     return Object.assign(res, readFilesSync(__dirname + path));
   }, {});

--- a/src/transforms/replace.ts
+++ b/src/transforms/replace.ts
@@ -45,7 +45,7 @@ export const fromFiles = (paths: string[]) => {
       return Object.assign(res, read);
     }
     return res;
-  }, Object.create(null));
+  }, {});
 
   return replace(foundReplacements);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,3 @@
-import { readFilesSync } from './fs_util';
-import * as Replace from './transforms/replace';
-
 export enum Mode {
   Prod = 'prod',
   Dev = 'dev',


### PR DESCRIPTION
This merges all replace transforms into one, meaning that we will only have to do a single AST pass for all these replacements.

- Use promises to find and load the replacement files in parallel
- Avoid loading replacement files that will not be enabled
- Merge all replacements together
- Use `fs.readdir(dir, {withFileTypes: true})` to avoid having to do `fs.stat` (I didn't know about this before. I haven't benchmarked whether it's better tbh)
- Remove some unused imports

I did a very quick benchmark and I see a 5% speed improvement on the total run, but I'm not entirely sure my benchmark was run sufficiently to be conclusive. Anyway, the more replacement transforms that get added, the more this will be worth it, so I think it's a good foundation.

Let me know if there is a part of this you don't like or find scary.