### PR TITLE
Add replacement for List.all

### DIFF
--- a/src/replacements/list/$elm$core$List$all.js
+++ b/src/replacements/list/$elm$core$List$all.js
@@ -1,9 +1,15 @@
-var $elm$core$List$all = F2(
-	function (isOkay, list) {
-		return !A2(
-			$elm$core$List$any,
-			function (a) {
-				return !isOkay(a);
-			},
-			list);
-	});
+var $elm$core$List$all = F2(function (isOkay, list) {
+  all: while (true) {
+    if (!list.b) {
+      return true;
+    }
+    else {
+      var x = list.a;
+      if (!isOkay(x)) {
+        return false;
+      }
+      list = list.b;
+      continue all;
+    }
+  }
+});

--- a/src/replacements/list/$elm$core$List$all.js
+++ b/src/replacements/list/$elm$core$List$all.js
@@ -1,0 +1,9 @@
+var $elm$core$List$all = F2(
+	function (isOkay, list) {
+		return !A2(
+			$elm$core$List$any,
+			function (a) {
+				return !isOkay(a);
+			},
+			list);
+	});


### PR DESCRIPTION
This makes `List.all` quite a lot faster. The problem is the original uses this implementation:
```elm
var $elm$core$List$all = F2(
	function (isOkay, list) {
		return !A2(
			$elm$core$List$any,
			A2($elm$core$Basics$composeL, $elm$core$Basics$not, isOkay),
			list);
	});
```

The `composeL` (or `<<` in Elm) is actually not very performant ([benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/WhatIsFaster/FunctionComposition.elm), [results](https://github.com/jfmengels/elm-benchmarks/blob/master/src/WhatIsFaster/FunctionComposition-Results-Chrome.png)). We could also make the same change by transforming `composeL`/`composeR` calls by anonymous functions, but that's more work. I do plan to add that, at which point we can probably remove this replacement (EDIT: done in #73).

I [benchmarked the change](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/ListAll.elm). This is after compilation with `elm-optimize-level-2` v0.2.3:

Results on Chrome:
![Screenshot from 2021-11-25 17-57-50](https://user-images.githubusercontent.com/3869412/143479952-181b13e3-416c-431a-88a8-2a0420418a0e.png)

Results on Firefox:

![Screenshot from 2021-11-25 17-57-15](https://user-images.githubusercontent.com/3869412/143479925-7737737a-b2c2-43e4-a885-2c123476be61.png)

I don't have a Safari readily available, but I'll try to get results later (work computer is a Mac, so I can get them later).