### PR TITLE
Add replacement for List.concatMap

### DIFF
--- a/src/replacements/list/$elm$core$List$concatMap.js
+++ b/src/replacements/list/$elm$core$List$concatMap.js
@@ -1,0 +1,13 @@
+var $elm$core$List$concatMap = F2(
+	function (fn, list) {
+		return A3(
+			$elm$core$List$foldr,
+			F2(
+				function (item, acc) {
+					return _Utils_ap(
+						fn(item),
+						acc);
+				}),
+			_List_Nil,
+			list);
+	});


### PR DESCRIPTION
This makes `List.concatMap` quite a lot faster, even compared to the "fast concatMap" that I've seen shared in some places.

I [benchmarked the change](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/ListConcatMap.elm):

Results on Chrome (+203%):
![](https://raw.githubusercontent.com/jfmengels/elm-benchmarks/master/src/ImprovingPerformance/ElmCore/ListConcatMap-Results-Chrome.png)

Results on Firefox (+62%):
![](https://raw.githubusercontent.com/jfmengels/elm-benchmarks/master/src/ImprovingPerformance/ElmCore/ListConcatMap-Results-FF.png)

I don't have a Safari readily available yet, but I'll try to get results later.