### PR TITLE
Add List concatMap replacement

### DIFF
--- a/src/replacements/list/$elm$core$List$concatMap.js
+++ b/src/replacements/list/$elm$core$List$concatMap.js
@@ -1,0 +1,18 @@
+var $elm$core$List$concatMap = F2(function (f, lists) {
+  if (!lists.b) {
+    return _List_Nil;
+  }
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (; lists.b.b; lists = lists.b) {
+    var xs = f(lists.a);
+    for (; xs.b; xs = xs.b) {
+      var next = _List_Cons(xs.a, _List_Nil);
+      end.b = next;
+      end = next;
+    }
+  }
+  end.b = f(lists.a);
+
+  return tmp.b;
+});


### PR DESCRIPTION
I'm back! My Elm solution from #66 was beat by the improvements `elm-optimize-level-2` already did by replacing `List.concat`. By applying the same technique on `concatMap`, we can make it faster than before.
This removes the need to iterate through the list twice (once for map, then once for concat).

(cc @brian-carroll who seems to have made the original series of these improvements on Lists)

Here are the [benchmarks](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/ListConcatMap.elm) results for Chrome:
![Screenshot from 2021-11-25 18-31-42](https://user-images.githubusercontent.com/3869412/143503026-e53989d0-40ed-46ea-b29a-204d96f4005e.png)

and for FIrefox:


![Screenshot from 2021-11-25 18-32-04](https://user-images.githubusercontent.com/3869412/143503032-1d5e5e9e-31b2-46b2-b520-71fa4f846ea8.png)

