### PR TITLE
Add replacement for Set.map

### DIFF
--- a/src/replacements/set/$elm$core$Set$map.js
+++ b/src/replacements/set/$elm$core$Set$map.js
@@ -1,0 +1,14 @@
+var $elm$core$Set$map = F2(
+  function (func, set) {
+    return A3(
+      $elm$core$Set$foldl,
+      F2(
+        function (x, acc) {
+          return A2(
+            $elm$core$Set$insert,
+            func(x),
+            acc);
+        }),
+      $elm$core$Set$empty,
+      set);
+  });

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -89,6 +89,7 @@ export const transform = async (
     [transforms.replacements != null, replacementTransformer ],
     [transforms.fastCurriedFns, Replace.from_file('/../replacements/faster-function-wrappers') ],
     [transforms.replaceListFunctions,  Replace.from_file('/../replacements/list') ],
+    [transforms.replaceSetFunctions,  Replace.from_file('/../replacements/set') ],
     [transforms.replaceStringFunctions, Replace.from_file('/../replacements/string') ],
     [transforms.v8Analysis, v8Debug],
     [transforms.variantShapes, normalizeVariantShapes],

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export type Transforms = {
   objectUpdate: ObjectUpdate | false;
   unusedValues: boolean;
   replaceListFunctions: boolean;
+  replaceSetFunctions: boolean;
   replaceStringFunctions: boolean;
   recordUpdates: boolean;
   v8Analysis: boolean;
@@ -89,6 +90,7 @@ export const emptyOpts: Transforms = {
   objectUpdate: false,
   unusedValues: false,
   replaceListFunctions: false,
+  replaceSetFunctions: false,
   replaceStringFunctions: false,
   recordUpdates: false,
   v8Analysis: false,
@@ -111,6 +113,7 @@ export function toolDefaults(o3Enabled: boolean, replacements: { string: string 
         objectUpdate: false,
         unusedValues: false,
         replaceListFunctions: true,
+        replaceSetFunctions: true,
         replaceStringFunctions: false,
         recordUpdates: o3Enabled,
         v8Analysis: false,
@@ -134,6 +137,7 @@ export function benchmarkDefaults(o3Enabled: boolean, replacements: { string: st
         objectUpdate: false,
         unusedValues: false,
         replaceListFunctions: true,
+        replaceSetFunctions: true,
         replaceStringFunctions: false,
         recordUpdates: o3Enabled,
         v8Analysis: false,
@@ -162,6 +166,7 @@ export const previous: Previous =
         objectUpdate: false,
         unusedValues: false,
         replaceListFunctions: false,
+        replaceSetFunctions: false,
         replaceStringFunctions: false,
         recordUpdates: false,
         v8Analysis: false,


### PR DESCRIPTION
The `elm/core` implementation did two passes over the set (`fromList (foldl (\x xs -> func x :: xs) [] set)`), but my implementation only does a single one.

I [benchmarked the change](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/SetMap.elm). This is after compilation with `elm-optimize-level-2` v0.2.3:

Results on Chrome:

![Screenshot from 2021-12-04 00-24-36](https://user-images.githubusercontent.com/3869412/144686945-7a35d77b-fa1a-4ac8-85d6-0d5659095118.png)

Results on Firefox:
![Screenshot from 2021-12-04 00-29-23](https://user-images.githubusercontent.com/3869412/144686978-1f4c1a30-dc88-48b9-9547-9a8f972c10ab.png)





I don't have a Safari readily available, but I'll try to get results later (work computer is a Mac, so I can get them later).