### PR TITLE
Add replacement for List.take

### DIFF
--- a/src/replacements/list/$elm$core$List$take.js
+++ b/src/replacements/list/$elm$core$List$take.js
@@ -1,0 +1,10 @@
+var $elm$core$List$take = F2(function(n, xs) {
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (var i = 0; i < n && xs.b; xs = xs.b, i++) {
+    var next = _List_Cons(xs.a, _List_Nil);
+    end.b = next;
+    end = next;
+  }
+  return tmp.b;
+});


### PR DESCRIPTION
This is applying the same technique from other List optimizations and applying it to `List.take`.

Benchmark can be found [here](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/ListTake.elm).

Here are the improvements for Chrome:
![Screenshot from 2021-12-14 17-07-40](https://user-images.githubusercontent.com/3869412/146037579-f46f010b-b878-4e5a-89d1-9589d34c8799.png)

and for Firefox:
![Screenshot from 2021-12-14 17-20-01](https://user-images.githubusercontent.com/3869412/146037610-4693175d-23d6-4fa1-8520-75eafc4fe215.png)

The results are very much alike when compiling with or without `elm-optimize-level-2`.
