### PR TITLE
Add replacement for List.filterMap

### DIFF
--- a/src/replacements/list/$elm$core$List$filterMap.js
+++ b/src/replacements/list/$elm$core$List$filterMap.js
@@ -1,0 +1,13 @@
+var $elm$core$List$filterMap = F2(function (f, xs) {
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (; xs.b; xs = xs.b) {
+    var m = f(xs.a);
+    if (!m.$) {
+      var next = _List_Cons(m.a, _List_Nil);
+      end.b = next;
+      end = next;
+    }
+  }
+  return tmp.b;
+});


### PR DESCRIPTION
This is applying the same technique from other List optimizations and applying it to `List.filterMap`.

Benchmark can be found [here](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/ListFilterMap.elm).

Here are the improvements (all taken using eol2) for Chrome:

![Screenshot from 2021-12-14 17-37-19](https://user-images.githubusercontent.com/3869412/146046379-a9fcf577-83b9-496c-8783-a27176f96fe6.png)


and for Firefox:
![Screenshot from 2021-12-14 18-04-47](https://user-images.githubusercontent.com/3869412/146046388-96b57f8e-0a42-41d4-a9fc-d5b7ac74f871.png)
