### PR TITLE
Add replacements for List.mapN functions

### DIFF
--- a/src/replacements/list/_List_map2.js
+++ b/src/replacements/list/_List_map2.js
@@ -1,0 +1,10 @@
+var _List_map2 = F3(function(f, xs, ys) {
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (; xs.b && ys.b; xs = xs.b, ys = ys.b) {
+    var next = _List_Cons(A2(f, xs.a, ys.a), _List_Nil);
+    end.b = next;
+    end = next;
+  }
+  return tmp.b;
+});

--- a/src/replacements/list/_List_map3.js
+++ b/src/replacements/list/_List_map3.js
@@ -1,0 +1,10 @@
+var _List_map3 = F4(function(f, xs, ys, zs) {
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (; xs.b && ys.b && zs.b; xs = xs.b, ys = ys.b, zs = zs.b) {
+    var next = _List_Cons(A3(f, xs.a, ys.a, zs.a), _List_Nil);
+    end.b = next;
+    end = next;
+  }
+  return tmp.b;
+});

--- a/src/replacements/list/_List_map4.js
+++ b/src/replacements/list/_List_map4.js
@@ -1,0 +1,10 @@
+var _List_map4 = F5(function(f, ws, xs, ys, zs) {
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (; ws.b && xs.b && ys.b && zs.b; ws = ws.b, xs = xs.b, ys = ys.b, zs = zs.b) {
+    var next = _List_Cons(A4(f, ws.a, xs.a, ys.a, zs.a), _List_Nil);
+    end.b = next;
+    end = next;
+  }
+  return tmp.b;
+});

--- a/src/replacements/list/_List_map5.js
+++ b/src/replacements/list/_List_map5.js
@@ -1,0 +1,10 @@
+var _List_map5 = F6(function(f, vs, ws, xs, ys, zs) {
+  var tmp = _List_Cons(undefined, _List_Nil);
+  var end = tmp;
+  for (; vs.b && ws.b && xs.b && ys.b && zs.b; vs = vs.b, ws = ws.b, xs = xs.b, ys = ys.b, zs = zs.b) {
+    var next = _List_Cons(A5(f, vs.a, ws.a, xs.a, ys.a, zs.a), _List_Nil);
+    end.b = next;
+    end = next;
+  }
+  return tmp.b;
+});


### PR DESCRIPTION
This improves the performance for all `List.map2`, `List.map3`, `List.map4` and `List.map5`, using the same idea as for other List replacements.

I have only [benchmarked it for `List.map2`](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/ListMap2.elm), which gives the following results (against eol2):

Chrome:

![](https://raw.githubusercontent.com/jfmengels/elm-benchmarks/master/src/ImprovingPerformance/ElmCore/ListMap2-Results-Chrome.png)

FF:

![](https://raw.githubusercontent.com/jfmengels/elm-benchmarks/master/src/ImprovingPerformance/ElmCore/ListMap2-Results-FF.png)
