### PR TITLE
Add replacement for String.repeat

### DIFF
--- a/src/replacements/string/$elm$core$String$repeat.js
+++ b/src/replacements/string/$elm$core$String$repeat.js
@@ -1,0 +1,15 @@
+var $elm$core$String$repeat = F2(
+  function (n, chunk) {
+    var result = '';
+    repeat:
+    while (true) {
+      if (n <= 0) {
+        return result;
+      } else {
+        result = (!(n & 1)) ? result : (result + chunk);
+        n = n >> 1;
+        chunk = chunk + chunk;
+        continue repeat;
+      }
+    }
+  });


### PR DESCRIPTION
This is a replacement for `String.repeat`

## Original

```elm
repeat : Int -> String -> String
repeat n chunk =
    repeatHelp n chunk ""

repeatHelp : Int -> String -> String -> String
repeatHelp n chunk result =
    if n <= 0 then
        result

    else
        repeatHelp (Bitwise.shiftRightBy 1 n) (chunk ++ chunk) <|
            if Bitwise.and n 1 == 0 then
                result

            else
                result ++ chunk
```

## Replacement

The replacement is equivalent to the following Elm code:

```elm
repeat : Int -> String -> String
repeat n chunk =
    repeatHelp n chunk ""


repeatHelp : Int -> String -> String -> String
repeatHelp n chunk result =
    if n <= 0 then
        result

    else
        repeatHelp (Bitwise.shiftRightBy 1 n)
            (chunk ++ chunk ++ "")
            (if Bitwise.and n 1 == 0 then
                result

             else
                result ++ chunk ++ ""
            )
```

The main improvements are:
- the function is made tailcall recursive (by removing the `<|`)
- `++ ""` has been added when concatenating strings, forcing the compiler to use `+` instead of the slower `_Utils_ap`. This was the biggest gain in performance.

For this PR, I have slightly altered the replacement to
- not have a `repeatHelp` function (its replacement is empty to remove it) by inlining `repeatHelp` inside `repeat`
- not have the unnecessary `+ ''` (that could be removed by the compiler IMO)
- remove the unnecessary temporary variables

These don't seem to have a noticeable effect as far as I can tell, but it reduces the bundle size ever so slightly maybe. Let me know if you want me to use the "original version".

## Results

[Benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/StringRepeat.elm) is run with `elm-optimize-level-2`.

Chrome:
![Screenshot from 2022-01-07 16-29-36](https://user-images.githubusercontent.com/3869412/148566415-505f28d5-a2ba-403d-94cc-995829d62692.png)

Firefox:
![Screenshot from 2022-01-07 16-29-14](https://user-images.githubusercontent.com/3869412/148566411-c48efd34-7850-400a-bef0-a687b72eaa69.png)

## Notes

String replacements seem to be disabled in all configurations for the tool and I'm not sure why. That also needs to change otherwise this replacement will not have any effect.