### PR TITLE
Add replacement for String.pad

### DIFF
--- a/src/replacements/string/$elm$core$String$pad.js
+++ b/src/replacements/string/$elm$core$String$pad.js
@@ -1,0 +1,16 @@
+var $elm$core$String$pad = F3(
+	function (n, _char, string) {
+		var half = (n - $elm$core$String$length(string)) / 2;
+		if (half <= 0) {
+			return string;
+		} else {
+			var flooredHalf = $elm$core$Basics$floor(half);
+			var repeated = A2(
+				$elm$core$String$repeat,
+				flooredHalf,
+				$elm$core$String$fromChar(_char));
+			return (_Utils_cmp(
+				flooredHalf,
+				$elm$core$Basics$ceiling(half)) < 0) ? (repeated + (string + (repeated + ''))) : (repeated + ($elm$core$String$fromChar(_char) + (string + (repeated + ''))));
+		}
+	});


### PR DESCRIPTION
This is a replacement for `String.pad`

## Original

```elm
pad : Int -> Char -> String -> String
pad n char string =
    let
        half =
            Basics.toFloat (n - length string) / 2
    in
    repeat (ceiling half) (fromChar char) ++ string ++ repeat (floor half) (fromChar char)
```

## Replacement

The replacement is equivalent to the following Elm code:

```elm
pad : Int -> Char -> String -> String
pad n char string =
    let
        half : Float
        half =
            Basics.toFloat (n - length string) / 2
    in
    if half <= 0 then
        string

    else
        let
            flooredHalf : Int
            flooredHalf =
                floor half

            repeated : String.String
            repeated =
                repeat flooredHalf (fromChar char)
        in
        if flooredHalf == ceiling half then
            repeated ++ string ++ repeated ++ ""

        else
            repeated ++ String.fromChar char ++ string ++ repeated ++ ""
```

The main improvements are:
- We only compute the padding for both sides once, and add an extra character when needed
- There's an added `+ ""` to force string concatenation using `+` instead of the slower `_Utils_ap`

## Results

[Benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/StringPad.elm) is run with `elm-optimize-level-2`.

Chrome:

![Screenshot from 2022-01-07 22-23-10](https://user-images.githubusercontent.com/3869412/148609223-f1d2248a-9ba9-45b9-a0ac-831cd508c315.png)


Firefox:

![Screenshot from 2022-01-07 22-18-35](https://user-images.githubusercontent.com/3869412/148608766-e8307f47-ec04-4ba8-947f-6c18e2a109f9.png)


When combined with the `String.repeat` improvements in #79, these are the improvements for Chrome:

![Screenshot from 2022-01-07 22-19-04](https://user-images.githubusercontent.com/3869412/148608877-a9a426db-4c81-46ad-9222-25f41d69e79b.png)
