### PR TITLE
Fix phantom comments causing runtime exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Upcoming
+
+- Fix "phantom comments" issue. The sourceFile's comments were intermingling
+  with optimized-record output causing runtime exceptions in some cases. It's
+  suspected to be an issue
+
+- Bump typescript compiler to 4.5.5
+
+

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "commander": "^6.0.0",
     "node-elm-compiler": "^5.0.4",
     "ts-union": "^2.2.1",
-    "typescript": "^3.9.7"
+    "typescript": "^4.5.5"
   }
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -40,7 +40,18 @@ export const transform = async (
   verbose: boolean,
   transforms: Transforms
 ): Promise<string> => {
-  let source = ts.createSourceFile('elm.js', jsSource, ts.ScriptTarget.ES2018);
+  /* First, remove comments from source.
+
+  We've encountered a bug when running some of the transforms (specifically the
+  record-update transform when the -O3 flag is enabled) where comments from the
+  source file appear interspersed throughout the transformed file. In some cases
+  this will result in runtime exceptions.
+ */
+  const sourceWithComments = ts.createSourceFile('n/a', jsSource, ts.ScriptTarget.ES2018);
+  const noCommentsPrinter = ts.createPrinter({ removeComments: true });
+  const jsSourceWithoutComments = noCommentsPrinter.printFile(sourceWithComments);
+
+  let source = ts.createSourceFile('elm.js', jsSourceWithoutComments, ts.ScriptTarget.ES2018);
 
   let parsedVariants = primitives;
   if (elmfile && transforms.variantShapes) {


### PR DESCRIPTION

- Fix "phantom comments" from JS source from intermingling w/ record-optimization output.
- Bump TS

Depends on https://github.com/mdgriffith/elm-optimize-level-2/pull/83 because of the addition of a changelog. Would point at the PR if I could.
