### PR TITLE
Correct AX and FX regex

### DIFF
--- a/src/transforms/utils/ElmWrappers.ts
+++ b/src/transforms/utils/ElmWrappers.ts
@@ -1,0 +1,22 @@
+const invocationRegex = /^A(?<arity>[1-9]+[0-9]*)$/;
+const wrapperRegex = /^F(?<arity>[1-9]+[0-9]*)$/;
+
+/* Checks whether the function is a A2/A3/A4/... function and if so returns the arity.
+ */
+export function parseAXFunction(str: string) : number | null {
+    const match = str.match(invocationRegex);
+    if (match && match.groups) {
+        return Number(match.groups.arity);
+    }
+    return null;
+}
+
+/* Checks whether the function is a F2/F3/F4/... function and if so returns the arity.
+ */
+export function parseFXFunction(str: string) : number | null {
+    const match = str.match(wrapperRegex);
+    if (match && match.groups) {
+        return Number(match.groups.arity);
+    }
+    return null;
+}


### PR DESCRIPTION
Fixes the issue reported in https://github.com/mdgriffith/elm-optimize-level-2/pull/90

The code was looking for `A2` wrappers and the likes, and extracting the arity out of that (2 for `A2`, 3 for `A3`...).
The root issue was that the regex used to match and extract that arity was too permissive, making functions like `$folkertdev$elm_sha2$Internal$SHA256$loopHelp` be considered as an Elm wrapper function with 256 arguments (`A256`...).

This happened in the `patterns` module used by the `passUnwrappedFunctions` transformer.

I fixed the issue by changing `/A.../;` to `/^A.../;` I also added a `$` at the end just to be safe.
Since this regex was re-declared in multiple modules (and even correct in one of them :man_facepalming: ), I mutualized them into a single helper module, and decided to give it a nicer API for the purpose of the transformer.