### PR TITLE
Bump node version in CI to reflect the tool's requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 16.x
 
     - name: Cache node_modules
       id: cache-node_modules


### PR DESCRIPTION
Currently CI is broken. I imagine it's since the latest bump to the tools requirement to run on Node >= 16.