### PR TITLE
Add replacement for String.startsWith

### DIFF
--- a/src/replacements/string/_String_startsWith.js
+++ b/src/replacements/string/_String_startsWith.js
@@ -3,10 +3,10 @@ var _String_startsWith = F2(
         var prefixLength = prefix.length;
         var i = -1;
         if (str.length < prefixLength) {
-            return $elm$core$Basics$False;
+            return false;
         }
         while (++i < prefixLength) {
-            if (prefix[i] !== str[i]) { return $elm$core$Basics$False; }
+            if (prefix[i] !== str[i]) { return false; }
         }
-        return $elm$core$Basics$True;
+        return true;
     });

--- a/src/replacements/string/_String_startsWith.js
+++ b/src/replacements/string/_String_startsWith.js
@@ -1,0 +1,12 @@
+var _String_startsWith = F2(
+    function (prefix, str) {
+        var prefixLength = prefix.length;
+        var i = -1;
+        if (str.length < prefixLength) {
+            return $elm$core$Basics$False;
+        }
+        while (++i < prefixLength) {
+            if (prefix[i] !== str[i]) { return $elm$core$Basics$False; }
+        }
+        return $elm$core$Basics$True;
+    });


### PR DESCRIPTION
Fixes #100

Note that the replacements for strings are not enabled by default. Maybe they should?

[Benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/StringStartsWith2.elm)

### Chrome

![](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/StringStartsWith2-Results-Chrome.png?raw=true)

### Firefox

![](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ElmCore/StringStartsWith2-Results-FF.png?raw=true)