### PR TITLE
Add supportArraysForHtml transformer

### DIFF
--- a/src/replacements/virtual-dom/_VirtualDom_nodeNS.js
+++ b/src/replacements/virtual-dom/_VirtualDom_nodeNS.js
@@ -1,0 +1,37 @@
+var _VirtualDom_nodeNS_usingArray = (namespace, tag, factList, kids) => {
+  for (var i = 0, descendantsCount = kids.length; i < kids.length; i++) {
+    descendantsCount += kids[i].b || 0;
+  }
+
+  return {
+    $: 1,
+    c: tag,
+    d: _VirtualDom_organizeFacts(factList),
+    e: kids,
+    f: namespace,
+    b: descendantsCount,
+  };
+}, _VirtualDom_nodeNS = F2(function (namespace, tag) {
+  return F2(function (factList, kidList) {
+    if (Array.isArray(kidList)) {
+      return _VirtualDom_nodeNS_usingArray(namespace, tag, factList, kidList);
+    }
+
+    for (var kids = [], descendantsCount = 0; kidList.b; kidList = kidList.b) // WHILE_CONS
+    {
+      var kid = kidList.a;
+      descendantsCount += kid.b || 0;
+      kids.push(kid);
+    }
+    descendantsCount += kids.length;
+
+    return {
+      $: 1,
+      c: tag,
+      d: _VirtualDom_organizeFacts(factList),
+      e: kids,
+      f: namespace,
+      b: descendantsCount,
+    };
+  });
+});

--- a/src/replacements/virtual-dom/_VirtualDom_organizeFacts.js
+++ b/src/replacements/virtual-dom/_VirtualDom_organizeFacts.js
@@ -1,0 +1,54 @@
+function _VirtualDom_organizeFacts_usingArray(factArray) {
+  for (var i = 0, facts = {}; i < factArray.length; i++) {
+    var entry = factArray[i];
+
+    var tag = entry.$;
+    var key = entry.n;
+    var value = entry.o;
+
+    if (tag === "a2") {
+      key === "className"
+        ? _VirtualDom_addClass(facts, key, _Json_unwrap(value))
+        : (facts[key] = _Json_unwrap(value));
+
+      continue;
+    }
+
+    var subFacts = facts[tag] || (facts[tag] = {});
+    tag === "a3" && key === "class"
+      ? _VirtualDom_addClass(subFacts, key, value)
+      : (subFacts[key] = value);
+  }
+
+  return facts;
+}
+
+function _VirtualDom_organizeFacts(factList) {
+  if (Array.isArray(factList)) {
+    return _VirtualDom_organizeFacts_usingArray(factList);
+  }
+
+  for (var facts = {}; factList.b; factList = factList.b) // WHILE_CONS
+  {
+    var entry = factList.a;
+
+    var tag = entry.$;
+    var key = entry.n;
+    var value = entry.o;
+
+    if (tag === "a2") {
+      key === "className"
+        ? _VirtualDom_addClass(facts, key, _Json_unwrap(value))
+        : (facts[key] = _Json_unwrap(value));
+
+      continue;
+    }
+
+    var subFacts = facts[tag] || (facts[tag] = {});
+    tag === "a3" && key === "class"
+      ? _VirtualDom_addClass(subFacts, key, value)
+      : (subFacts[key] = value);
+  }
+
+  return facts;
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -103,7 +103,7 @@ export const transform = async (
     [transforms.variantShapes, normalizeVariantShapes],
     [transforms.inlineFunctions, createFunctionInlineTransformer(verbose, transforms.fastCurriedFns)],
     [transforms.inlineEquality, inlineEquality()],
-    [true, supportArraysForHtml],
+    [transforms.arraysForHtml, supportArraysForHtml],
     [transforms.inlineNumberToString, inlineNumberToString()],
     [
       transforms.listLiterals == InlineLists.AsObjects,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -25,6 +25,7 @@ import { inlineNumberToString } from './transforms/inlineNumberToString';
 import { reportFunctionStatusInBenchmarks, v8Debug } from './transforms/analyze';
 import { recordUpdate } from './transforms/recordUpdate';
 import * as Replace from './transforms/replace';
+import {supportArraysForHtml} from "./transforms/supportArraysForHtml";
 
 export type Options = {
   compile: boolean;
@@ -102,6 +103,7 @@ export const transform = async (
     [transforms.variantShapes, normalizeVariantShapes],
     [transforms.inlineFunctions, createFunctionInlineTransformer(verbose, transforms.fastCurriedFns)],
     [transforms.inlineEquality, inlineEquality()],
+    [true, supportArraysForHtml],
     [transforms.inlineNumberToString, inlineNumberToString()],
     [
       transforms.listLiterals == InlineLists.AsObjects,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -25,7 +25,7 @@ import { inlineNumberToString } from './transforms/inlineNumberToString';
 import { reportFunctionStatusInBenchmarks, v8Debug } from './transforms/analyze';
 import { recordUpdate } from './transforms/recordUpdate';
 import * as Replace from './transforms/replace';
-import {supportArraysForHtml} from "./transforms/supportArraysForHtml";
+import {supportArraysForHtml, supportArraysForHtmlReplacements} from "./transforms/supportArraysForHtml";
 
 export type Options = {
   compile: boolean;
@@ -94,6 +94,7 @@ export const transform = async (
     [transforms.fastCurriedFns, '/../replacements/faster-function-wrappers'],
     [transforms.replaceListFunctions, '/../replacements/list'],
     [transforms.replaceStringFunctions, '/../replacements/string'],
+    [transforms.arraysForHtml, supportArraysForHtmlReplacements],
   ]);
 
   let inlineCtx: InlineContext | undefined;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -102,9 +102,9 @@ export const transform = async (
     [transforms.replacements != null || replacements.length > 0, await Replace.fromFiles(transforms.replacements || {}, replacements)],
     [transforms.v8Analysis, v8Debug],
     [transforms.variantShapes, normalizeVariantShapes],
+    [transforms.arraysForHtml, supportArraysForHtml],
     [transforms.inlineFunctions, createFunctionInlineTransformer(verbose, transforms.fastCurriedFns)],
     [transforms.inlineEquality, inlineEquality()],
-    [transforms.arraysForHtml, supportArraysForHtml],
     [transforms.inlineNumberToString, inlineNumberToString()],
     [
       transforms.listLiterals == InlineLists.AsObjects,

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -1,0 +1,18 @@
+/*
+
+TODO Docs
+
+*/
+
+import ts from 'typescript';
+
+
+export const supportArraysForHtml : ts.TransformerFactory<ts.SourceFile> = context => {
+  return sourceFile => {
+    const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      return ts.visitEachChild(node, visitor, context);
+    };
+
+    return ts.visitNode(sourceFile, visitor);
+  };
+};

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -19,7 +19,7 @@ export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = contex
         const functionName = arity ? getName(node.arguments[0]) : node.expression.text;
 
         if (functionName && isOptimizableFunction(functionName)) {
-          return ts.factory.updateCallExpression(
+          node = ts.factory.updateCallExpression(
             node,
             node.expression,
             node.typeArguments,

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -35,6 +35,13 @@ export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = contex
 };
 
 function removeListFromArray(node: ts.Expression): ts.Expression {
+  if (ts.isCallExpression(node)
+    && ts.isIdentifier(node.expression)
+    && node.expression.text === '_List_fromArray'
+  ) {
+    return node.arguments[0];
+  }
+
   return node;
 }
 

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -58,6 +58,6 @@ function getName(expr: ts.Expression): string | null {
   return null;
 }
 
-function isOptimizableFunction(_functionName: string): boolean {
-  return true;
+function isOptimizableFunction(functionName: string): boolean {
+  return functionName.startsWith('$elm$html$Html$');
 }

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -5,11 +5,22 @@ TODO Docs
 */
 
 import ts from 'typescript';
+import {parseAXFunction} from "./utils/ElmWrappers";
 
 
 export const supportArraysForHtml : ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
     const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      if (ts.isCallExpression(node)
+        && ts.isIdentifier(node.expression)
+        && node.arguments.length > 0
+      ) {
+        const callExpression = node.expression;
+        const arity = parseAXFunction(callExpression.text);
+        if (arity) {
+        } else {
+        }
+      }
       return ts.visitEachChild(node, visitor, context);
     };
 

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -10,8 +10,19 @@ import {parseAXFunction} from "./utils/ElmWrappers";
 
 export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
+    const knownFunctionsToOptimize : Set<string> = new Set(['$elm$html$Html$node']);
+
     const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
-      const knownFunctionsToOptimize : Set<string> = new Set(['$elm$html$Html$node']);
+      if (ts.isVariableDeclaration(node)
+        && ts.isIdentifier(node.name)
+        && node.initializer
+        && ts.isCallExpression(node.initializer)
+        && ts.isIdentifier(node.initializer.expression)
+        && node.initializer.expression.text === '_VirtualDom_node'
+      ) {
+        knownFunctionsToOptimize.add(node.name.text);
+        return ts.visitEachChild(node, visitor, context);
+      }
 
       if (ts.isCallExpression(node)
         && ts.isIdentifier(node.expression)

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -7,10 +7,11 @@ TODO Docs
 import ts from 'typescript';
 import {parseAXFunction} from "./utils/ElmWrappers";
 
+export const supportArraysForHtmlReplacements = '/../replacements/virtual-dom';
 
 export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
-    const knownFunctionsToOptimize : Set<string> = new Set(['$elm$html$Html$node']);
+    const knownFunctionsToOptimize: Set<string> = new Set(['$elm$html$Html$node']);
 
     const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
       if (ts.isVariableDeclaration(node)
@@ -71,6 +72,6 @@ function getName(expr: ts.Expression): string | null {
   return null;
 }
 
-function isOptimizableFunction(functionName: string, knownFunctionsToOptimize : Set<string>): boolean {
+function isOptimizableFunction(functionName: string, knownFunctionsToOptimize: Set<string>): boolean {
   return knownFunctionsToOptimize.has(functionName);
 }

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -11,7 +11,7 @@ import {parseAXFunction} from "./utils/ElmWrappers";
 export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
     const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
-      const knownFunctionsToOptimize : Set<string> = new Set();
+      const knownFunctionsToOptimize : Set<string> = new Set(['$elm$html$Html$node']);
 
       if (ts.isCallExpression(node)
         && ts.isIdentifier(node.expression)
@@ -61,5 +61,5 @@ function getName(expr: ts.Expression): string | null {
 }
 
 function isOptimizableFunction(functionName: string, knownFunctionsToOptimize : Set<string>): boolean {
-  return functionName.startsWith('$elm$html$Html$') || knownFunctionsToOptimize.has(functionName);
+  return knownFunctionsToOptimize.has(functionName);
 }

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -21,6 +21,10 @@ export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = contex
           arity
             ? {functionName: getName(node.arguments[0]), args: node.arguments.slice(1)}
             : {functionName: callExpression.text, args: node.arguments};
+
+        if (functionName && isOptimizableFunction(functionName)) {
+
+        }
       }
       return ts.visitEachChild(node, visitor, context);
     };
@@ -34,4 +38,8 @@ function getName(expr: ts.Expression): string | null {
     return expr.text;
   }
   return null;
+}
+
+function isOptimizableFunction(_functionName: string): boolean {
+  return true;
 }

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -42,6 +42,12 @@ function removeListFromArray(node: ts.Expression): ts.Expression {
     return node.arguments[0];
   }
 
+  if (ts.isIdentifier(node)
+    && node.text === '_List_Nil'
+  ) {
+    return ts.factory.createArrayLiteralExpression([]);
+  }
+
   return node;
 }
 

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -8,7 +8,7 @@ import ts from 'typescript';
 import {parseAXFunction} from "./utils/ElmWrappers";
 
 
-export const supportArraysForHtml : ts.TransformerFactory<ts.SourceFile> = context => {
+export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
     const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
       if (ts.isCallExpression(node)
@@ -17,9 +17,10 @@ export const supportArraysForHtml : ts.TransformerFactory<ts.SourceFile> = conte
       ) {
         const callExpression = node.expression;
         const arity = parseAXFunction(callExpression.text);
-        if (arity) {
-        } else {
-        }
+        const {functionName, args} =
+          arity
+            ? {functionName: getName(node.arguments[0]), args: node.arguments.slice(1)}
+            : {functionName: callExpression.text, args: node.arguments};
       }
       return ts.visitEachChild(node, visitor, context);
     };
@@ -27,3 +28,10 @@ export const supportArraysForHtml : ts.TransformerFactory<ts.SourceFile> = conte
     return ts.visitNode(sourceFile, visitor);
   };
 };
+
+function getName(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr)) {
+    return expr.text;
+  }
+  return null;
+}

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -11,6 +11,8 @@ import {parseAXFunction} from "./utils/ElmWrappers";
 export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
     const visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      const knownFunctionsToOptimize : Set<string> = new Set();
+
       if (ts.isCallExpression(node)
         && ts.isIdentifier(node.expression)
         && node.arguments.length > 0
@@ -18,7 +20,7 @@ export const supportArraysForHtml: ts.TransformerFactory<ts.SourceFile> = contex
         const arity = parseAXFunction(node.expression.text);
         const functionName = arity ? getName(node.arguments[0]) : node.expression.text;
 
-        if (functionName && isOptimizableFunction(functionName)) {
+        if (functionName && isOptimizableFunction(functionName, knownFunctionsToOptimize)) {
           node = ts.factory.updateCallExpression(
             node,
             node.expression,
@@ -58,6 +60,6 @@ function getName(expr: ts.Expression): string | null {
   return null;
 }
 
-function isOptimizableFunction(functionName: string): boolean {
-  return functionName.startsWith('$elm$html$Html$');
+function isOptimizableFunction(functionName: string, knownFunctionsToOptimize : Set<string>): boolean {
+  return functionName.startsWith('$elm$html$Html$') || knownFunctionsToOptimize.has(functionName);
 }

--- a/src/transforms/supportArraysForHtml.ts
+++ b/src/transforms/supportArraysForHtml.ts
@@ -1,6 +1,56 @@
 /*
 
-TODO Docs
+## Goal
+
+This transformer aims to avoid unnecessary Elm List to JavaScript Array conversions when it comes to `elm/html` functions.
+
+Here is a small example:
+
+```elm
+Html.div [ Html.Attributes.class "some", Html.Attributes.class "class" ] [ a, b, c ]
+```
+gets compiled to
+```js
+A2(
+  $elm$html$Html$div,
+  _List_fromArray([
+      $elm$html$Html$Attributes$class("some"),
+      $elm$html$Html$Attributes$class("class")
+  ]),
+  _List_fromArray([a, b, c])
+);
+```
+
+Through `_List_fromArray`, the attributes and children are converted from JavaScript Arrays to Elm Lists.
+This conversion has a runtime cost, and Elm lists are slower to iterate through as well.
+
+The idea behind this transformer is to remove these `_List_fromArray` calls and to keep the JavaScript Arrays as such,
+and to have the underlying functions able to iterate through JavaScript Arrays as well. Taking the example from before,
+the result would end up being:
+```js
+A2(
+  $elm$html$Html$div,
+  [
+      $elm$html$Html$Attributes$class("some"),
+      $elm$html$Html$Attributes$class("class")
+  ],
+  [a, b, c]
+);
+```
+
+This change will only be applied when the arguments are literal lists, not when they are variables or more complex expressions.
+Further work could potentially increase the number of cases that we apply this change.
+
+Elm Lists will have to be supported still, because this transformer will not be able to replace all attributes and children.
+
+## Explanation of the transformer
+
+1. When this transformer is enabled, replacements for `_VirtualDom_nodeNS` and `_VirtualDom_organizeFacts` are introduced.
+   These replacements will make the 2 functions (which are at the root of the VirtualDom functions) support JavaScript Arrays.
+   More replacements should probably be added to support SVG and custom nodes.
+2. Detect which functions can benefit from this optimization. Currently, it's only the functions that call `_VirtualDom_node`,
+   but we could extend this further with a bit more analysis.
+3. Remove `_List_fromArray` from the arguments from the functions detected in 2.
 
 */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type Transforms = {
   variantShapes: boolean;
   inlineNumberToString: boolean;
   inlineEquality: boolean;
+  arraysForHtml: boolean;
   inlineFunctions: boolean;
   passUnwrappedFunctions: boolean;
   listLiterals: InlineLists | false;
@@ -79,6 +80,7 @@ export const emptyOpts: Transforms = {
   inlineNumberToString: false,
   inlineFunctions: false,
   inlineEquality: false,
+  arraysForHtml: false,
   listLiterals: false,
   passUnwrappedFunctions: false,
   arrowFns: false,
@@ -100,6 +102,7 @@ export function toolDefaults(o3Enabled: boolean, replacements: { string: string 
         variantShapes: true,
         inlineNumberToString: false,
         inlineEquality: true,
+        arraysForHtml: true,
         inlineFunctions: true,
         listLiterals: false,
         passUnwrappedFunctions: true,
@@ -123,6 +126,7 @@ export function benchmarkDefaults(o3Enabled: boolean, replacements: { string: st
         variantShapes: true,
         inlineNumberToString: false,
         inlineEquality: true,
+        arraysForHtml: true,
         inlineFunctions: true,
         listLiterals: false,
         passUnwrappedFunctions: true,
@@ -151,6 +155,7 @@ export const previous: Previous =
         variantShapes: true,
         inlineNumberToString: false,
         inlineEquality: true,
+        arraysForHtml: true,
         inlineFunctions: true,
         listLiterals: false,
         passUnwrappedFunctions: true,

--- a/test/supportArraysForHtml.test.ts
+++ b/test/supportArraysForHtml.test.ts
@@ -103,3 +103,22 @@ test('it removes the _List_fromArray call for partially applied functions', () =
   const { actual, expected } = transformCode(initialCode, expectedOutputCode, supportArraysForHtml);
   expect(actual).toBe(expected);
 });
+
+test('should not remove _List_fromArray from non-supported functions', () => {
+  const initialCode = `
+    var a = A2(
+      $author$project$Module$someFunction,
+      _List_fromArray([1, 2, 3]),
+      value
+    );
+
+    var b = $author$project$Module$someOtherFunction(
+      _List_fromArray([1, 2, 3])
+    );
+    
+    var c = _List_fromArray([1, 2, 3]);
+  `;
+
+  const { actual, expected } = transformCode(initialCode, initialCode, supportArraysForHtml);
+  expect(actual).toBe(expected);
+});

--- a/test/supportArraysForHtml.test.ts
+++ b/test/supportArraysForHtml.test.ts
@@ -1,0 +1,105 @@
+import ts from 'typescript';
+
+import { transformCode } from './helpers/transformCode';
+import {supportArraysForHtml} from "../src/transforms/supportArraysForHtml";
+
+test('it removes the _List_fromArray call for functions that create DOM nodes', () => {
+  const initialCode = `
+    var view = A2(
+      $elm$html$Html$div,
+      _List_fromArray([
+        $elm$html$Html$Attributes$class('some'),
+        $elm$html$Html$Attributes$class('classes'),
+        $elm$html$Html$Attributes$id('id')
+      ]),
+      _List_fromArray([
+        $elm$html$Html$text('Some'),
+        A2(
+          $elm$html$Html$button,
+          _List_fromArray([$elm$html$Html$Attributes$class('button')]),
+          _List_fromArray([$elm$html$Html$text('Button')])
+        ),
+        $elm$html$Html$text('to make some'),
+        A2(
+          $elm$html$Html$p,
+          _List_Nil,
+          _List_fromArray([$elm$html$Html$text('context')])
+        )
+      ])
+    );
+  `;
+
+  const expectedOutputCode = `
+    var view = A2(
+      $elm$html$Html$div,
+      [
+        $elm$html$Html$Attributes$class('some'),
+        $elm$html$Html$Attributes$class('classes'),
+        $elm$html$Html$Attributes$id('id')
+      ],
+      [
+        $elm$html$Html$text('Some'),
+        A2(
+          $elm$html$Html$button,
+          [$elm$html$Html$Attributes$class('button')],
+          [$elm$html$Html$text('Button')]
+        ),
+        $elm$html$Html$text('to make some'),
+        A2(
+          $elm$html$Html$p,
+          [],
+          [$elm$html$Html$text('context')]
+        )
+      ]
+    );
+  `;
+
+  const { actual, expected } = transformCode(initialCode, expectedOutputCode, supportArraysForHtml);
+  expect(actual).toBe(expected);
+});
+
+
+test('it removes the _List_fromArray call for partially applied functions', () => {
+  const initialCode = `
+    var partialView1 = A2(
+      $elm$html$Html$node,
+      'web-component',
+      _List_fromArray([
+        $elm$html$Html$Attributes$class('some'),
+        $elm$html$Html$Attributes$class('classes'),
+        $elm$html$Html$Attributes$id('id')
+      ])
+    );
+
+    var partialView2 = $elm$html$Html$div(
+      _List_fromArray([
+        $elm$html$Html$Attributes$class('some'),
+        $elm$html$Html$Attributes$class('classes'),
+        $elm$html$Html$Attributes$id('id')
+      ])
+    );
+  `;
+
+  const expectedOutputCode = `
+    var partialView1 = A2(
+      $elm$html$Html$node,
+      'web-component',
+      [
+        $elm$html$Html$Attributes$class('some'),
+        $elm$html$Html$Attributes$class('classes'),
+        $elm$html$Html$Attributes$id('id')
+      ]
+    );
+
+    var partialView2 = $elm$html$Html$div(
+      [
+        $elm$html$Html$Attributes$class('some'),
+        $elm$html$Html$Attributes$class('classes'),
+        $elm$html$Html$Attributes$id('id')
+      ]
+    );
+  `;
+
+  const { actual, expected } = transformCode(initialCode, expectedOutputCode, supportArraysForHtml);
+  expect(actual).toBe(expected);
+});

--- a/test/supportArraysForHtml.test.ts
+++ b/test/supportArraysForHtml.test.ts
@@ -5,6 +5,9 @@ import {supportArraysForHtml} from "../src/transforms/supportArraysForHtml";
 
 test('it removes the _List_fromArray call for functions that create DOM nodes', () => {
   const initialCode = `
+    var $elm$html$Html$div = _VirtualDom_node('div');
+    var $elm$html$Html$button = _VirtualDom_node('button');
+    var $elm$html$Html$p = _VirtualDom_node('p');
     var view = A2(
       $elm$html$Html$div,
       _List_fromArray([
@@ -30,6 +33,9 @@ test('it removes the _List_fromArray call for functions that create DOM nodes', 
   `;
 
   const expectedOutputCode = `
+    var $elm$html$Html$div = _VirtualDom_node('div');
+    var $elm$html$Html$button = _VirtualDom_node('button');
+    var $elm$html$Html$p = _VirtualDom_node('p');
     var view = A2(
       $elm$html$Html$div,
       [
@@ -61,6 +67,7 @@ test('it removes the _List_fromArray call for functions that create DOM nodes', 
 
 test('it removes the _List_fromArray call for partially applied functions', () => {
   const initialCode = `
+    var $elm$html$Html$div = _VirtualDom_node('div');
     var partialView1 = A2(
       $elm$html$Html$node,
       'web-component',
@@ -81,6 +88,7 @@ test('it removes the _List_fromArray call for partially applied functions', () =
   `;
 
   const expectedOutputCode = `
+    var $elm$html$Html$div = _VirtualDom_node('div');
     var partialView1 = A2(
       $elm$html$Html$node,
       'web-component',


### PR DESCRIPTION
I ran this on [this benchmark](https://github.com/jfmengels/elm-benchmarks/blob/master/src/NativeJsArrayExploration/ArraysForHtml.elm) and got around a 60% performance increase on Chrome, and a 50% increase on Firefox.

Explanation of the transformer can be found at the top of `supportArraysForHtml.ts`.

More work can (and probably should) be done to increase the number of places that this transformation applies (doesn't apply to SVG or custom nodes for instance).

I have not yet tested this extensively on a codebase.

The idea for this optimization was pitched to me by @evancz a while ago.