### PR TITLE
Add replacement for List.singleton

### DIFF
--- a/src/replacements/list/$elm$core$List$singleton.js
+++ b/src/replacements/list/$elm$core$List$singleton.js
@@ -1,0 +1,3 @@
+var $elm$core$List$singleton = function (value) {
+  return _List_Cons(value, _List_Nil);
+};


### PR DESCRIPTION
Replaces `List.singleton` by a function that doesn't call `_List_fromArray`.

According to [this benchmark](https://jsbench.me/9ikw6tcypa), it speeds up the function by 4.5 times.